### PR TITLE
Add Star Wars API wrapper implementation and GraphQL endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-graphql</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.yaml</groupId>
+					<artifactId>snakeyaml</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/sovtech/starwars/graphql/controller/StarWarsController.java
+++ b/src/main/java/com/sovtech/starwars/graphql/controller/StarWarsController.java
@@ -1,0 +1,36 @@
+package com.sovtech.starwars.graphql.controller;
+
+import com.sovtech.starwars.graphql.data.model.api.response.PersonResponse;
+import com.sovtech.starwars.graphql.service.StarWarsService;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author asopia
+ */
+@Controller
+public class StarWarsController {
+    private final StarWarsService service;
+
+    public StarWarsController(StarWarsService service) {
+        this.service = service;
+    }
+
+    @QueryMapping
+    public Flux<PersonResponse> getAllPeople(@Argument int  page) {
+        return service.getAllPeople(page);
+    }
+
+    @QueryMapping
+    public Flux<PersonResponse> searchPerson(@Argument String name){
+        return service.searchPerson(name);
+    }
+
+    @QueryMapping
+    public Mono<PersonResponse> getPerson(@Argument String name){
+        return service.getPerson(name);
+    }
+}

--- a/src/main/java/com/sovtech/starwars/graphql/data/model/api/response/PeopleResponse.java
+++ b/src/main/java/com/sovtech/starwars/graphql/data/model/api/response/PeopleResponse.java
@@ -1,0 +1,20 @@
+package com.sovtech.starwars.graphql.data.model.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author asopia
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PeopleResponse {
+    private int count;
+    private String next;
+    private String previous;
+    private List<PersonResponse> results;
+}

--- a/src/main/java/com/sovtech/starwars/graphql/data/model/api/response/PeopleResponse.java
+++ b/src/main/java/com/sovtech/starwars/graphql/data/model/api/response/PeopleResponse.java
@@ -17,4 +17,14 @@ public class PeopleResponse {
     private String next;
     private String previous;
     private List<PersonResponse> results;
+
+    public static PersonResponse mapToPerson(PersonResponse personResult) {
+        return PersonResponse.builder()
+                .name(personResult.getName())
+                .height(personResult.getHeight())
+                .mass(personResult.getMass())
+                .gender(personResult.getGender())
+                .homeworld(personResult.getHomeworld())
+                .build();
+    }
 }

--- a/src/main/java/com/sovtech/starwars/graphql/data/model/api/response/PersonResponse.java
+++ b/src/main/java/com/sovtech/starwars/graphql/data/model/api/response/PersonResponse.java
@@ -1,0 +1,21 @@
+package com.sovtech.starwars.graphql.data.model.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author asopia
+ */
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PersonResponse {
+    private String name;
+    private String height;
+    private String mass;
+    private String gender;
+    private String homeworld;
+}

--- a/src/main/java/com/sovtech/starwars/graphql/service/StarWarsService.java
+++ b/src/main/java/com/sovtech/starwars/graphql/service/StarWarsService.java
@@ -1,0 +1,16 @@
+package com.sovtech.starwars.graphql.service;
+
+import com.sovtech.starwars.graphql.data.model.api.response.PersonResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author asopia
+ */
+public interface StarWarsService {
+    Flux<PersonResponse> getAllPeople(int page);
+
+    Flux<PersonResponse> searchPerson(String name);
+
+    Mono<PersonResponse> getPerson(String name);
+}

--- a/src/main/java/com/sovtech/starwars/graphql/service/impl/StarWarsServiceImpl.java
+++ b/src/main/java/com/sovtech/starwars/graphql/service/impl/StarWarsServiceImpl.java
@@ -28,16 +28,28 @@ public class StarWarsServiceImpl implements StarWarsService {
                 .retrieve()
                 .bodyToMono(PeopleResponse.class)
                 .flatMapIterable(PeopleResponse::getResults)
-                .map(PeopleResponse::mapToPerson);    }
+                .map(PeopleResponse::mapToPerson);
+    }
 
     @Override
     public Flux<PersonResponse> searchPerson(String name) {
-       return null;
+        return webClient.get()
+                .uri("/people/?search={name}", name)
+                .retrieve()
+                .bodyToMono(PeopleResponse.class)
+                .flatMapIterable(PeopleResponse::getResults)
+                .map(PeopleResponse::mapToPerson);
     }
 
     @Override
     public Mono<PersonResponse> getPerson(String name) {
-        return null;
+        return webClient.get()
+                .uri("/people/?search={name}", name)
+                .retrieve()
+                .bodyToMono(PeopleResponse.class)
+                .flatMapIterable(PeopleResponse::getResults)
+                .next()
+                .map(PeopleResponse::mapToPerson);
     }
 
 }

--- a/src/main/java/com/sovtech/starwars/graphql/service/impl/StarWarsServiceImpl.java
+++ b/src/main/java/com/sovtech/starwars/graphql/service/impl/StarWarsServiceImpl.java
@@ -1,0 +1,30 @@
+package com.sovtech.starwars.graphql.service.impl;
+
+import com.sovtech.starwars.graphql.data.model.api.response.PersonResponse;
+import com.sovtech.starwars.graphql.service.StarWarsService;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author asopia
+ */
+@Service
+public class StarWarsServiceImpl implements StarWarsService {
+
+    @Override
+    public Flux<PersonResponse> getAllPeople(int page) {
+        return null;
+    }
+
+    @Override
+    public Flux<PersonResponse> searchPerson(String name) {
+       return null;
+    }
+
+    @Override
+    public Mono<PersonResponse> getPerson(String name) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/sovtech/starwars/graphql/service/impl/StarWarsServiceImpl.java
+++ b/src/main/java/com/sovtech/starwars/graphql/service/impl/StarWarsServiceImpl.java
@@ -1,8 +1,10 @@
 package com.sovtech.starwars.graphql.service.impl;
 
+import com.sovtech.starwars.graphql.data.model.api.response.PeopleResponse;
 import com.sovtech.starwars.graphql.data.model.api.response.PersonResponse;
 import com.sovtech.starwars.graphql.service.StarWarsService;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -11,11 +13,22 @@ import reactor.core.publisher.Mono;
  */
 @Service
 public class StarWarsServiceImpl implements StarWarsService {
+    private static final String BASE_URL = "https://swapi.dev/api";
+
+    private final WebClient webClient;
+
+    public StarWarsServiceImpl(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl(BASE_URL).build();
+    }
 
     @Override
     public Flux<PersonResponse> getAllPeople(int page) {
-        return null;
-    }
+        return webClient.get()
+                .uri("/people/?page={page}", page)
+                .retrieve()
+                .bodyToMono(PeopleResponse.class)
+                .flatMapIterable(PeopleResponse::getResults)
+                .map(PeopleResponse::mapToPerson);    }
 
     @Override
     public Flux<PersonResponse> searchPerson(String name) {

--- a/src/main/resources/graphql/schema.graphql
+++ b/src/main/resources/graphql/schema.graphql
@@ -1,0 +1,14 @@
+type Query {
+    getAllPeople(page: Int = 1): [Person]
+    searchPerson(name: String!): [Person]
+    getPerson(name: String!): Person
+
+}
+
+type Person {
+    name: String!
+    height: String!
+    mass: String!
+    gender: String!
+    homeworld: String!
+}


### PR DESCRIPTION
This pull request adds support for the Star Wars API through a Spring Boot service using the WebClient to make HTTP requests to the API. The project also includes a GraphQL endpoint for querying the API, providing a simple and intuitive way for frontend developers to access the data.

Here is a summary of the changes made in this pull request:

- Added StarWarsServiceImpl class, which implements the StarWarsService interface and provides implementations for the getAllPeople, searchPerson, and getPerson methods using the WebClient to fetch data from the Star Wars API.
- Refactored StarWarsServiceImpl to use WebClient, injecting it into the constructor and setting the base URL to https://swapi.dev/api.
- Implemented searchPerson and getPerson methods in StarWarsServiceImpl, allowing for searching and retrieving individual people from the API.
- Added StarWarsController class, which defines three endpoints for accessing the Star Wars API through the StarWarsService using GraphQL and the graphql-java-kickstart library's @QueryMapping annotation.
- Updated the getAllPeople endpoint in StarWarsController to accept a page parameter using the @Argument annotation.

These changes provide a more efficient and maintainable way to consume data from the Star Wars API, and the addition of the GraphQL endpoint makes it easier for developers to interact with the API in a more intuitive way.```
